### PR TITLE
Fixed the typo for stack-trace-exposure@v1.0

### DIFF
--- a/src/python/detectors/stack_trace_exposure/stack_trace_exposure.py
+++ b/src/python/detectors/stack_trace_exposure/stack_trace_exposure.py
@@ -21,7 +21,7 @@ def stack_trace_exposure_noncompliant(text):
 # {/fact}
 
 
-# {fact rule=stack-trace-exposur@v1.0 defects=0}
+# {fact rule=stack-trace-exposure@v1.0 defects=0}
 @app_flask.route('/compliant/<text>')
 def stack_trace_exposure_compliant(text):
     try:


### PR DESCRIPTION
*Description of changes:*
* Rules Added: python/stack-trace-exposure@v1.0
* Fixed the typo in the name.