### PR TITLE
Add compliant and noncompliant examples of python/pytorch-avoid-softmax-with-nllloss@v1.0

### DIFF
--- a/src/python/detectors/pytorch_avoid_softmax_with_nllloss/pytorch_avoid_softmax_with_nllloss.py
+++ b/src/python/detectors/pytorch_avoid_softmax_with_nllloss/pytorch_avoid_softmax_with_nllloss.py
@@ -1,0 +1,29 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=pytorch-avoid-softmax-with-nllloss@v1.0 defects=1}
+def pytorch_avoid_softmax_with_nllloss_noncompliant():
+    import math
+    import torch
+    import torch.nn as nn
+    # Noncompliant: `softmax` output is used directly with `NLLLoss`.
+    m = nn.functional.softmax(dim=1)
+    loss = nn.NLLLoss()
+    input = torch.randn(3, 5, requires_grad=True)
+    target = torch.tensor([1, 0, 4])
+    output = loss(m(input), target)
+# {/fact}
+
+
+# {fact rule=pytorch-avoid-softmax-with-nllloss@v1.0 defects=0}
+def pytorch_avoid_softmax_with_nllloss_compliant():
+    import math
+    import torch
+    import torch.nn as nn
+    # Compliant: `LogSoftmax` is used with `NLLLoss`.
+    m = nn.LogSoftmax(dim=1)
+    loss = nn.NLLLoss()
+    input = torch.randn(3, 5, requires_grad=True)
+    target = torch.tensor([1, 0, 4])
+    output = loss(m(input), target)
+# {/fact}


### PR DESCRIPTION
 *Description of changes:*
* Rules Added: python/pytorch-avoid-softmax-with-nllloss@v1.0
* Added compliant and non compliant examples
