### PR TITLE
Add compliant and noncompliant examples of tensorflow-avoid-using-nondeterministic-api@v1.0

### DIFF
--- a/src/python/detectors/tensorflow_avoid_using_nondeterministic_api/tensorflow_avoid_using_nondeterministic_api.py
+++ b/src/python/detectors/tensorflow_avoid_using_nondeterministic_api/tensorflow_avoid_using_nondeterministic_api.py
@@ -1,0 +1,30 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=tensorflow-avoid-using-nondeterministic-api@v1.0 defects=1}
+def tensorflow_avoid_using_nondeterministic_api_noncompliant():
+    import tensorflow as tf
+    data = tf.ones((1, 1))
+    # Noncompliant: uses non-deterministic API.
+    tf.compat.v1.Session(
+        target='', graph=None, config=None
+    )
+    layer = tf.keras.layers.Input(shape=[1])
+    model = tf.keras.models.Model(inputs=layer, outputs=layer)
+    model.compile(loss="categorical_crossentropy", metrics="AUC")
+    model.fit(x=data, y=data)
+# {/fact}
+
+
+# {fact rule=tensorflow-avoid-using-nondeterministic-api@v1.0 defects=0}
+def tensorflow_avoid_using_nondeterministic_api_compliant():
+    import tensorflow as tf
+    tf.random.set_seed(0)
+    # Compliant: uses deterministic API.
+    tf.config.experimental.enable_op_determinism()
+    data = tf.ones((1, 1))
+    layer = tf.keras.layers.Input(shape=[1])
+    model = tf.keras.models.Model(inputs=layer, outputs=layer)
+    model.compile(loss="categorical_crossentropy", metrics="AUC")
+    model.fit(x=data, y=data)
+# {/fact}


### PR DESCRIPTION
*Description of changes:*
* Rules Added: python/tensorflow-avoid-using-nondeterministic-api@v1.0
* Added compliant and non compliant examples