### PR TITLE
Add compliant and noncompliant examples of python/tensorflow-control-sources-of-randomness@v1.0

### DIFF
--- a/src/python/detectors/tensorflow_control_sources_of_randomness/tensorflow_control_sources_of_randomness.py
+++ b/src/python/detectors/tensorflow_control_sources_of_randomness/tensorflow_control_sources_of_randomness.py
@@ -1,0 +1,18 @@
+#  Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#  SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=tensorflow-control-sources-of-randomness@v1.0 defects=1}
+def tensorflow_control_sources_of_randomness_noncompliant():
+    import tensorflow as tf
+    # Noncompliant: seed is not set.
+    print(tf.random.uniform([1]))
+# {/fact}
+
+
+# {fact rule=tensorflow-control-sources-of-randomness@v1.0 defects=0}
+def tensorflow_control_sources_of_randomness_compliant(seed):
+    import tensorflow as tf
+    # Compliant: sets the seed.
+    tf.random.set_seed(seed)
+    print(tf.random.uniform([1]))
+# {/fact}


### PR DESCRIPTION
*Description of changes:*
* Rules Added: python/tensorflow-control-sources-of-randomness@v1.0
* Added compliant and non compliant examples