### PR TITLE
Add compliant and noncompliant examples of python/pytorch_create_tensors_directly_on_device@v1.0

### DIFF
--- a/src/python/detectors/pytorch_create_tensors_directly_on_device/pytorch_create_tensors_directly_on_device.py
+++ b/src/python/detectors/pytorch_create_tensors_directly_on_device/pytorch_create_tensors_directly_on_device.py
@@ -1,7 +1,7 @@
 # Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-# {fact rule=pytorch_create_tensors_directly_on_device@v1.0 defects=1}
+# {fact rule=pytorch-create-tensors-directly-on-device@v1.0 defects=1}
 def pytorch_create_tensors_directly_on_device_noncompliant():
     import torch
     t = torch.ones(list(range(1, 11)), dtype=torch.float64)
@@ -10,7 +10,7 @@ def pytorch_create_tensors_directly_on_device_noncompliant():
 # {/fact}
 
 
-# {fact rule=pytorch_create_tensors_directly_on_device@v1.0 defects=0}
+# {fact rule=pytorch-create-tensors-directly-on-device@v1.0 defects=0}
 def pytorch_create_tensors_directly_on_device_compliant():
     import torch
     # Compliant: tensor is directly created on device.

--- a/src/python/detectors/pytorch_create_tensors_directly_on_device/pytorch_create_tensors_directly_on_device.py
+++ b/src/python/detectors/pytorch_create_tensors_directly_on_device/pytorch_create_tensors_directly_on_device.py
@@ -1,0 +1,18 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+# {fact rule=pytorch_create_tensors_directly_on_device@v1.0 defects=1}
+def pytorch_create_tensors_directly_on_device_noncompliant():
+    import torch
+    t = torch.ones(list(range(1, 11)), dtype=torch.float64)
+    # Noncompliant: tensor is created on cpu and then moved to device.
+    t.cuda()
+# {/fact}
+
+
+# {fact rule=pytorch_create_tensors_directly_on_device@v1.0 defects=0}
+def pytorch_create_tensors_directly_on_device_compliant():
+    import torch
+    # Compliant: tensor is directly created on device.
+    t = torch.tensor([1, 2, 3, 4], device="cuda")
+# {/fact}


### PR DESCRIPTION
*Description of changes:*
* Rules Added: python/pytorch_create_tensors_directly_on_device@v1.0
* Added compliant and non compliant examples